### PR TITLE
support grunt 0.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ module.exports = function (grunt) {
 
 
 ## Release History
+* 0.2.0 - Grunt 0.4.0 support.
 * 0.1.2 - Added `.jshintrc` support. [Example .jshintrc](https://github.com/circusbred/grunt-linter/blob/master/.jshintrc)
 * 0.1.1 - Made `options` optional
 * 0.1.0 - Forked from grunt-jslint; first release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "grunt-linter",
 	"description": "Validates JavaScript files with JSLint or JSHint",
-	"version": "0.1.4",
+	"version": "0.2.0",
 	"homepage": "https://github.com/circusbred/grunt-linter",
 	"contributors": [
 		{
@@ -32,10 +32,10 @@
 		"node": "*"
 	},
 	"dependencies": {
-		"grunt": "~0.3.11"
+		"grunt": "~0.4.0"
 	},
 	"devDependencies": {
-		"grunt": "~0.3.11"
+		"grunt": "~0.4.0"
 	},
 	"keywords": [
 		"gruntplugin",

--- a/tasks/linter.js
+++ b/tasks/linter.js
@@ -14,6 +14,7 @@ var linter,
 module.exports = function (grunt) {
 	'use strict';
 
+
 	/**
 	 * Grabs a config option from the `linter` namespace
 	 *
@@ -25,6 +26,8 @@ module.exports = function (grunt) {
 	}
 
 	var underscore, isJSLint, jshintrc, directives, globals,
+		// are we stupid? changing APIs/namespaces and not documenting them is pretty fucking cool
+		isStupid = false,
 		templates = {},
 		options = conf('options') || {};
 
@@ -38,6 +41,7 @@ module.exports = function (grunt) {
 
 		// 0.4.x
 		if (grunt.util && grunt.util._) {
+			isStupid = true;
 			return grunt.util._;
 		}
 
@@ -55,7 +59,15 @@ module.exports = function (grunt) {
 	templates.errors_only = grunt.file.read(__dirname + '/templates/errors-only.tmpl');
 	templates.junit = grunt.file.read(__dirname + '/templates/junit.tmpl');
 
-	jshintrc = grunt.file.findup('.', '.jshintrc');
+
+	if (isStupid) {
+		jshintrc = grunt.file.findup('.jshintrc');
+
+	} else {
+		jshintrc = grunt.file.findup('.', '.jshintrc');
+
+	}
+
 	if (jshintrc) {
 		jshintrc = grunt.file.readJSON(jshintrc);
 


### PR DESCRIPTION
grunt 0.4 changed a bunch of stuff (including templating).  i'm no longer using grunt's `template.process` method, but underscore's `template` method instead.
